### PR TITLE
Changing opc config key.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -382,7 +382,7 @@ Configuration Example
          #password: bar
          #verify_ssl_cert: true
 
-      php_apcu:
+      php_opc:
         scheme: http
         host: localhost
         port: 80


### PR DESCRIPTION
Doc incorrectly had 'apcu' as key, changed to 'opc' after testing.